### PR TITLE
Fix 4.0.2 issues and latest swiftlint issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         - git clone https://github.com/IBM-Swift/Package-Builder.git
       script: ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.1
       sudo: required
       language: objective-c
       env: TEST_DESTINATION="OS=11.0,name=iPhone 7"
@@ -21,13 +21,13 @@ matrix:
         - bundle exec danger
         - set -o pipefail && xcodebuild test -workspace ViaSwiftUtils.xcworkspace -scheme ViaSwiftUtils_iOS -destination "$TEST_DESTINATION" | xcpretty
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.1
       sudo: required
       language: objective-c
       env: TEST_DESTINATION="OS=9.3,name=iPhone 6"
       install:
         - ./install_swiftlint.sh
         - bundle install
-      
+
 
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       osx_image: xcode9.1
       sudo: required
       language: objective-c
-      env: TEST_DESTINATION="OS=11.0,name=iPhone 7"
+      env: TEST_DESTINATION="OS=11.1,name=iPhone 7"
       install:
         - ./install_swiftlint.sh
         - bundle install

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Sources/ViaSwiftUtils/Foundation/ForceUnwrappingOperators.swift
+++ b/Sources/ViaSwiftUtils/Foundation/ForceUnwrappingOperators.swift
@@ -33,7 +33,6 @@ infix operator !!
 /// - Note:
 /// [chapter 'When to Force Unwrap' from Advanced Swift](https://www.objc.io/books/advanced-swift/)
 
-// swiftlint:disable:next force_unwrapping
 public func !! <T>(wrapped: T?, failureText: @autoclosure () -> String) -> T {
     if let x = wrapped { return x }
     fatalError(failureText ())

--- a/Sources/ViaSwiftUtils/Foundation/MutableCollection+Shuffle.swift
+++ b/Sources/ViaSwiftUtils/Foundation/MutableCollection+Shuffle.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 
-// swiftlint:disable:next line_length
 public extension MutableCollection where Index == Int {
 
     /// implements [FisherYates](https://en.wikipedia.org/wiki/Fisher–Yates_shuffle) to shuffle elements in place

--- a/Sources/ViaSwiftUtils/Foundation/TimeInterval+Converter.swift
+++ b/Sources/ViaSwiftUtils/Foundation/TimeInterval+Converter.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-fileprivate let formatter = DateFormatter()
+private let formatter = DateFormatter()
 
 extension TimeInterval {
     

--- a/Sources/ViaSwiftUtils/UIKit/String+Words.swift
+++ b/Sources/ViaSwiftUtils/UIKit/String+Words.swift
@@ -29,7 +29,7 @@ public extension String {
 
         self.enumerateSubstrings(in: range, options: .byWords) { (substring, _, _, _) in
             if let word = substring {
-                newLongestWord = word.characters.count > newLongestWord.characters.count ? word : newLongestWord
+                newLongestWord = word.count > newLongestWord.count ? word : newLongestWord
             }
         }
 

--- a/Tests/ViaSwiftUtilsTests/Date_ComponentAccessorsTest.swift
+++ b/Tests/ViaSwiftUtilsTests/Date_ComponentAccessorsTest.swift
@@ -45,7 +45,7 @@ class DateComponentAccessorsTest: XCTestCase {
         let currentYear = Date().localizedYear
         
         // Then
-        XCTAssertEqual(currentYear.characters.count, 4, "Expected currentyear to have 4 characters")
+        XCTAssertEqual(currentYear.count, 4, "Expected currentyear to have 4 characters")
     }
         
     func testHistoricalYear() {
@@ -56,7 +56,7 @@ class DateComponentAccessorsTest: XCTestCase {
         let localizedString = fallOfRome.localizedYear
 
         // Then
-        XCTAssertEqual(localizedString.characters.count, 3, "Expected year of the fall of west rome to have 3 characters")
+        XCTAssertEqual(localizedString.count, 3, "Expected year of the fall of west rome to have 3 characters")
     }
     
 }

--- a/install_swiftlint.sh
+++ b/install_swiftlint.sh
@@ -7,7 +7,7 @@
 set -e
 
 SWIFTLINT_PKG_PATH="/tmp/SwiftLint.pkg"
-SWIFTLINT_PKG_URL="https://github.com/realm/SwiftLint/releases/download/0.20.1/SwiftLint.pkg"
+SWIFTLINT_PKG_URL="https://github.com/realm/SwiftLint/releases/download/0.23.1/SwiftLint.pkg"
 
 wget --output-document=$SWIFTLINT_PKG_PATH $SWIFTLINT_PKG_URL
 


### PR DESCRIPTION
Swift 4.0.2 issues:

* `x.characters.count` -> `x.count`

Latest swiftlint issues:

* Prefer `private` over `fileprivate`
* Colon violation
* Superfluous `swiftlint:disable`s now throw errors 🎉 