### PR TITLE
Update swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,47 +2,124 @@ included:
   - Sources
   - iOSTests
   - Example
+
 disabled_rules: # rule identifiers to exclude from running
   - trailing_whitespace
 
 opt_in_rules:
-  - empty_count
-  - force_unwrapping
-  - file_header
-  - explicit_init
-  - closure_spacing
-  - overridden_super_call
-  - redundant_nil_coalescing
-  - private_outlet
-  - nimble_operator
+  - anyobject_protocol
+  - array_init
   - attributes
-  - operator_usage_whitespace
+  - closure_body_length
   - closure_end_indentation
-  - first_where
-  - sorted_imports
-  - object_literal
-  - number_separator
-  - prohibited_super_call
+  - closure_spacing
+  - collection_alignment
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - convenience_type
+  - discouraged_optional_boolean
+  - discouraged_optional_collection
+  - empty_collection_literal
+  - empty_count
+  - empty_enum_arguments
+  - empty_string
+  - empty_xctest_method
+  - expiring_todo
+  - explicit_init
+  - extension_access_modifier
+  - fallthrough
   - fatal_error_message
+  - file_header
+  - file_name
+  - first_where
+  - flatmap_over_map_reduce
+  - force_unwrapping
+  - function_default_parameter_at_end
+  - identical_operands
+  - implicit_return
+  - implicitly_unwrapped_optional
+  - joined_default_parameter
+  - last_where
+  - legacy_multiple
+  - legacy_random
+  - let_var_whitespace
+  - literal_expression_end_indentation
+  - lower_acl_than_parent
+  - modifier_order
+  - multiline_arguments
+  - multiline_function_chains
+  - multiline_literal_brackets
+  - multiline_parameters
+  - multiline_parameters_brackets
+  - nimble_operator
+  - no_grouping_extension
+  - nslocalizedstring_require_bundle
+  - number_separator
+  - object_literal
+  - operator_usage_whitespace
+  - overridden_super_call
+  - override_in_extension
+  - pattern_matching_keywords
+  - prefixed_toplevel_constant
+  - private_action
+  - private_outlet
+  - prohibited_super_call
+  - quick_discouraged_call
+  - quick_discouraged_focused_test
+  - quick_discouraged_pending_test
+  - raw_value_for_camel_cased_codable_enum
+  - reduce_into
+  - redundant_nil_coalescing
+  - required_enum_case
+  - single_test_class
+  - sorted_first_last
+  - sorted_imports
+  - strict_fileprivate
+  - switch_case_on_newline
+  - toggle_bool
+  - trailing_closure
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - unowned_variable_capture
+  - untyped_error_in_catch
   - vertical_parameter_alignment_on_call
+  - xct_specific_matcher
+  - yoda_condition
 
-number_separator:
-  minimum_length: 5
 excluded: # paths to ignore during linting. overridden by `included`.
   - Carthage
   - Submodules
 
+closure_body_length:
+  warning: 30
+  error: 40
+
+number_separator:
+  minimum_length: 5
+
+modifier_order:
+  preferred_modifier_order:
+    - acl
+    - override
+    - final
+
 line_length:
-  - 160
-  - 200
+  warning: 160
+  error: 200
+  ignores_comments: true
   
 type_body_length:
-  - 300 # warning
-  - 400 # error
+  warning: 300
+  error: 400
 
 function_body_length:
-  - 60
-  - 120
+  warning: 60
+  error: 120
+
+vertical_whitespace:
+  max_empty_lines: 2
 
 file_header:
   required_pattern: |

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -23,25 +23,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
+    //swiftlint:disable:next discouraged_optional_collection
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         // Override point for customization after application launch.
         return true
     }
-
-    func applicationWillResignActive(_ application: UIApplication) {
-
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-    }
-
 }

--- a/Sources/ViaSwiftUtils/Foundation/Dictionary+MapValues.swift
+++ b/Sources/ViaSwiftUtils/Foundation/Dictionary+MapValues.swift
@@ -39,8 +39,8 @@ public extension Dictionary {
     /// - parameter transform: The transformation the values will be going through
     /// - returns: new dictionary with the mapped values but the same keys
     func mapValues<NewValue>(_ transform: (Value) -> NewValue) -> [Key: NewValue] {
-        return [Key: NewValue](map {(key, value) in
-            return (key, transform(value))
+        return [Key: NewValue](map { key, value in
+            (key, transform(value))
         })
     }
 }

--- a/Sources/ViaSwiftUtils/Foundation/ForceUnwrappingOperators.swift
+++ b/Sources/ViaSwiftUtils/Foundation/ForceUnwrappingOperators.swift
@@ -37,7 +37,7 @@ public func !! <T>(wrapped: T?, failureText: @autoclosure () -> String) -> T {
     // swiftlint:disable:next identifier_name
     if let x = wrapped { return x }
     fatalError(failureText())
-}
+}   
 
 infix operator !?
 

--- a/Sources/ViaSwiftUtils/Foundation/Sequence+Helpers.swift
+++ b/Sources/ViaSwiftUtils/Foundation/Sequence+Helpers.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionType+Helpers.swift
+//  Sequence+Helpers.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.
@@ -24,14 +24,14 @@ public extension Sequence where Iterator.Element: Hashable {
     /// - returns: an array containing the unique elements
     func unique() -> [Iterator.Element] {
         var seen: Set<Iterator.Element> = []
-        return filter({ (element) -> Bool in
+        return filter { element -> Bool in
             if seen.contains(element) {
                 return false
-            } else {
-                seen.insert(element)
-                return true
             }
-        })
+
+            seen.insert(element)
+            return true
+        }
     }
     
 }

--- a/Sources/ViaSwiftUtils/Foundation/TimeInterval+Converter.swift
+++ b/Sources/ViaSwiftUtils/Foundation/TimeInterval+Converter.swift
@@ -18,9 +18,9 @@
 
 import Foundation
 
-private let formatter = DateFormatter()
-
 extension TimeInterval {
+
+    private static let formatter = DateFormatter()
     
     /// Returns a string representation of the time interval representing video or music playtime.
     /// In minutes and seconds, in `en_US` output is for example "4:36" for 4minutes and 36secs.
@@ -35,7 +35,6 @@ extension TimeInterval {
         return components.string(from: self) ?? "?"
     }
 
-    // swiftlint:disable:next line_length
     /// [Data Formatting Guide]: https://developer.apple.com/library/prerelease/content/documentation/Cocoa/Conceptual/DataFormatting/DataFormatting.html#//apple_ref/doc/uid/10000029i
     ///
     /// Convenience method returns a string representation of the time interval initialized by using a given format string as a template
@@ -50,10 +49,10 @@ extension TimeInterval {
     /// - Parameter locale: (optional) locale to use for the string conversion. Defaults to en_US_POSIX.
     public func string(withFormat format: String, locale: Locale = Locale(identifier: "en_US_POSIX")) -> String {
         let date = Date(timeIntervalSince1970: self)
-        formatter.dateFormat = format
-        formatter.locale = locale
+        TimeInterval.formatter.dateFormat = format
+        TimeInterval.formatter.locale = locale
         
-        return String(formatter.string(from: date))
+        return String(TimeInterval.formatter.string(from: date))
     }
     
 }

--- a/Sources/ViaSwiftUtils/UIKit/NibView.swift
+++ b/Sources/ViaSwiftUtils/UIKit/NibView.swift
@@ -32,7 +32,7 @@ open class NibView: UIView {
     ///
     /// - parameter coder: The instance of class NSCoder
     ///
-    required public init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.didEncode = aDecoder.decodeBool(forKey: didEncodeKey)
         if didEncode == false {

--- a/Sources/ViaSwiftUtils/UIKit/String+Words.swift
+++ b/Sources/ViaSwiftUtils/UIKit/String+Words.swift
@@ -27,7 +27,7 @@ public extension String {
         let range = startIndex..<endIndex
         var newLongestWord = ""
 
-        self.enumerateSubstrings(in: range, options: .byWords) { (substring, _, _, _) in
+        self.enumerateSubstrings(in: range, options: .byWords) { substring, _, _, _ in
             if let word = substring {
                 newLongestWord = word.count > newLongestWord.count ? word : newLongestWord
             }
@@ -43,7 +43,7 @@ public extension String {
         let range = startIndex..<endIndex
         var count = 0
 
-        self.enumerateSubstrings(in: range, options: .byWords) { (word, _, _, _) in
+        self.enumerateSubstrings(in: range, options: .byWords) { word, _, _, _ in
             if word != nil { count += 1 }
         }
 

--- a/Sources/ViaSwiftUtils/UIKit/UIControl+States.swift
+++ b/Sources/ViaSwiftUtils/UIKit/UIControl+States.swift
@@ -1,5 +1,6 @@
+//swiftlint:disable:this file_name
 //
-//  UIControlState+AllStates.swift
+//  UIControl+States.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.
@@ -15,6 +16,7 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+
 import UIKit
 
 public extension UIControl.State {

--- a/Sources/ViaSwiftUtils/UIKit/UIImage+Color.swift
+++ b/Sources/ViaSwiftUtils/UIKit/UIImage+Color.swift
@@ -18,13 +18,13 @@
 
 import UIKit
 
-extension UIImage {
+public extension UIImage {
 
     /// Convenience initializer to create an image with a uniform color
     ///
     /// - parameter color:       The color of the image created
     /// - parameter size:        The size of the image created
-    public convenience init?(color: UIColor?, size: CGSize = CGSize(width: 1.0, height: 1.0)) {
+    convenience init?(color: UIColor?, size: CGSize = CGSize(width: 1.0, height: 1.0)) {
         defer {
             UIGraphicsEndImageContext()
         }

--- a/Sources/ViaSwiftUtils/UIKit/UIImageView+Rotation.swift
+++ b/Sources/ViaSwiftUtils/UIKit/UIImageView+Rotation.swift
@@ -18,7 +18,9 @@
 
 import UIKit
 
-internal let viewRotationAnimationKey = "ViaSwiftUtils.SpinAnimation"
+enum RotationAnimation {
+    static let key = "ViaSwiftUtils.SpinAnimation"
+}
 
 public extension UIView {
     
@@ -43,13 +45,13 @@ public extension UIView {
     }
     
     final var isRotating: Bool {
-        return layer.animation(forKey: viewRotationAnimationKey) != nil
+        return layer.animation(forKey: RotationAnimation.key) != nil
     }
     
     ///  Starts animating the image like an activityIndicator.
     /// - parameter duration: an NSTimeInterval duration the animation should take
     final func startRotating(_ animationDuration: AnimationDuration = .normal, isRemovedOnCompletion: Bool = true) {
-        layer.removeAnimation(forKey: viewRotationAnimationKey)
+        layer.removeAnimation(forKey: RotationAnimation.key)
         isHidden = false
         let animation = CABasicAnimation(keyPath: "transform.rotation.z")
         animation.fromValue = CGFloat(0.0)
@@ -57,12 +59,12 @@ public extension UIView {
         animation.duration = animationDuration.duration
         animation.repeatCount = HUGE
         animation.isRemovedOnCompletion = isRemovedOnCompletion
-        layer.add(animation, forKey: viewRotationAnimationKey)
+        layer.add(animation, forKey: RotationAnimation.key)
     }
     
     /// Stops rotating the image
     final func stopRotating() {
-        layer.removeAnimation(forKey: viewRotationAnimationKey)
+        layer.removeAnimation(forKey: RotationAnimation.key)
         isHidden = true
     }
 }

--- a/ViaSwiftUtils.xcodeproj/project.pbxproj
+++ b/ViaSwiftUtils.xcodeproj/project.pbxproj
@@ -10,9 +10,9 @@
 		33AED1841ECE0814002B70CD /* RandomAccessCollection+SafeAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AED1831ECE0814002B70CD /* RandomAccessCollection+SafeAccessTests.swift */; };
 		3C0754B31DD0CFE6004DAB38 /* TestStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3C0754AF1DD0C15C004DAB38 /* TestStoryboard.storyboard */; };
 		3C0754B51DD0D5CA004DAB38 /* TestViewWithoutOwner.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3C0754B41DD0D5CA004DAB38 /* TestViewWithoutOwner.xib */; };
-		3C48A8241DB8CD060014CBE9 /* UIImage+ColorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C48A8231DB8CD060014CBE9 /* UIImage+ColorTest.swift */; };
-		3C5C99581DB8E8EC00083A4E /* TimeInterval+ConverterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5C99571DB8E8EC00083A4E /* TimeInterval+ConverterTest.swift */; };
-		3C5C995A1DB8EDE700083A4E /* UIView+XibTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5C99591DB8EDE700083A4E /* UIView+XibTest.swift */; };
+		3C48A8241DB8CD060014CBE9 /* UIImageColorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C48A8231DB8CD060014CBE9 /* UIImageColorTest.swift */; };
+		3C5C99581DB8E8EC00083A4E /* TimeIntervalConverterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5C99571DB8E8EC00083A4E /* TimeIntervalConverterTest.swift */; };
+		3C5C995A1DB8EDE700083A4E /* UIViewXibTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5C99591DB8EDE700083A4E /* UIViewXibTest.swift */; };
 		3C5C995E1DB8F7D300083A4E /* TestViewWithOwner.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3C5C995D1DB8F7D300083A4E /* TestViewWithOwner.xib */; };
 		3C5C996A1DB8F9BE00083A4E /* NibViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5C99691DB8F9BE00083A4E /* NibViewTest.swift */; };
 		740682711D3630AA00FEA974 /* CollectionShuffledTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740682701D3630AA00FEA974 /* CollectionShuffledTest.swift */; };
@@ -20,10 +20,10 @@
 		740682751D36969D00FEA974 /* Dictionary+MapValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740682731D36969D00FEA974 /* Dictionary+MapValuesTests.swift */; };
 		740682771D3696A500FEA974 /* Date_ComponentAccessorsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740682761D3696A500FEA974 /* Date_ComponentAccessorsTest.swift */; };
 		740682791D3696AA00FEA974 /* Date_ComparableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740682781D3696AA00FEA974 /* Date_ComparableTest.swift */; };
-		7406827B1D3696B100FEA974 /* UIButton+StateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7406827A1D3696B100FEA974 /* UIButton+StateTests.swift */; };
-		7406827E1D36976200FEA974 /* UIImageView_RotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7406827C1D3696B700FEA974 /* UIImageView_RotationTests.swift */; };
-		740CDBD51F2613270071BF63 /* Locale+Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740CDBD41F2613270071BF63 /* Locale+Swizzling.swift */; };
-		740CDBD71F2614FF0071BF63 /* TimeInterval+ConverterTestsArabic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740CDBD61F2614FF0071BF63 /* TimeInterval+ConverterTestsArabic.swift */; };
+		7406827B1D3696B100FEA974 /* UIButtonStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7406827A1D3696B100FEA974 /* UIButtonStateTests.swift */; };
+		7406827E1D36976200FEA974 /* UIImageViewRotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7406827C1D3696B700FEA974 /* UIImageViewRotationTests.swift */; };
+		740CDBD51F2613270071BF63 /* NSLocale+Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740CDBD41F2613270071BF63 /* NSLocale+Swizzling.swift */; };
+		740CDBD71F2614FF0071BF63 /* TimeIntervalConverterArabicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740CDBD61F2614FF0071BF63 /* TimeIntervalConverterArabicTest.swift */; };
 		742194991D785F1000A73CF0 /* Date_TimesBetween.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742194951D785C5F00A73CF0 /* Date_TimesBetween.swift */; };
 		742C87921F2748F500DC39AE /* CountableRange+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87711F2748F500DC39AE /* CountableRange+Random.swift */; };
 		742C87931F2748F500DC39AE /* CountableRange+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87711F2748F500DC39AE /* CountableRange+Random.swift */; };
@@ -52,9 +52,9 @@
 		742C87AA1F2748F500DC39AE /* RandomAccessCollection+SafeAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87791F2748F500DC39AE /* RandomAccessCollection+SafeAccess.swift */; };
 		742C87AB1F2748F500DC39AE /* RandomAccessCollection+SafeAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87791F2748F500DC39AE /* RandomAccessCollection+SafeAccess.swift */; };
 		742C87AC1F2748F500DC39AE /* RandomAccessCollection+SafeAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87791F2748F500DC39AE /* RandomAccessCollection+SafeAccess.swift */; };
-		742C87AD1F2748F500DC39AE /* SequenceType+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C877A1F2748F500DC39AE /* SequenceType+Helpers.swift */; };
-		742C87AE1F2748F500DC39AE /* SequenceType+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C877A1F2748F500DC39AE /* SequenceType+Helpers.swift */; };
-		742C87AF1F2748F500DC39AE /* SequenceType+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C877A1F2748F500DC39AE /* SequenceType+Helpers.swift */; };
+		742C87AD1F2748F500DC39AE /* Sequence+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C877A1F2748F500DC39AE /* Sequence+Helpers.swift */; };
+		742C87AE1F2748F500DC39AE /* Sequence+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C877A1F2748F500DC39AE /* Sequence+Helpers.swift */; };
+		742C87AF1F2748F500DC39AE /* Sequence+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C877A1F2748F500DC39AE /* Sequence+Helpers.swift */; };
 		742C87B01F2748F500DC39AE /* SignedInteger+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C877B1F2748F500DC39AE /* SignedInteger+Random.swift */; };
 		742C87B11F2748F500DC39AE /* SignedInteger+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C877B1F2748F500DC39AE /* SignedInteger+Random.swift */; };
 		742C87B21F2748F500DC39AE /* SignedInteger+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C877B1F2748F500DC39AE /* SignedInteger+Random.swift */; };
@@ -72,8 +72,8 @@
 		742C87C41F2748F500DC39AE /* NibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87821F2748F500DC39AE /* NibView.swift */; };
 		742C87C51F2748F500DC39AE /* UIButton+States.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87831F2748F500DC39AE /* UIButton+States.swift */; };
 		742C87C71F2748F500DC39AE /* UIButton+States.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87831F2748F500DC39AE /* UIButton+States.swift */; };
-		742C87C81F2748F500DC39AE /* UIControlState+States.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87841F2748F500DC39AE /* UIControlState+States.swift */; };
-		742C87CA1F2748F500DC39AE /* UIControlState+States.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87841F2748F500DC39AE /* UIControlState+States.swift */; };
+		742C87C81F2748F500DC39AE /* UIControl+States.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87841F2748F500DC39AE /* UIControl+States.swift */; };
+		742C87CA1F2748F500DC39AE /* UIControl+States.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87841F2748F500DC39AE /* UIControl+States.swift */; };
 		742C87CB1F2748F500DC39AE /* UIImage+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87851F2748F500DC39AE /* UIImage+Color.swift */; };
 		742C87CD1F2748F500DC39AE /* UIImage+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87851F2748F500DC39AE /* UIImage+Color.swift */; };
 		742C87CE1F2748F500DC39AE /* UIImage+Rounding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C87861F2748F500DC39AE /* UIImage+Rounding.swift */; };
@@ -117,8 +117,8 @@
 		74DC1D111D215094007F1853 /* PushNotificationPayload.apns in Resources */ = {isa = PBXBuildFile; fileRef = 74DC1D101D215094007F1853 /* PushNotificationPayload.apns */; };
 		74DC1D131D2150B5007F1853 /* ViaSwiftUtilsTests_tvOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DC1D121D2150B5007F1853 /* ViaSwiftUtilsTests_tvOSTests.swift */; };
 		CE18E17D1D912A87003C8267 /* CGPoint+OperatorsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE18E17B1D912A82003C8267 /* CGPoint+OperatorsTest.swift */; };
-		CE2433281D913EB4001D6CC1 /* CGVector+OperatorsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2433261D913EB0001D6CC1 /* CGVector+OperatorsTest.swift */; };
-		CE65B3621D8AAD9700AA9B2B /* String+WordsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE65B3611D8AAD9700AA9B2B /* String+WordsTest.swift */; };
+		CE2433281D913EB4001D6CC1 /* CGVectorOperatorsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2433261D913EB0001D6CC1 /* CGVectorOperatorsTest.swift */; };
+		CE65B3621D8AAD9700AA9B2B /* StringWordsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE65B3611D8AAD9700AA9B2B /* StringWordsTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -206,9 +206,9 @@
 		33AED1831ECE0814002B70CD /* RandomAccessCollection+SafeAccessTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RandomAccessCollection+SafeAccessTests.swift"; sourceTree = "<group>"; };
 		3C0754AF1DD0C15C004DAB38 /* TestStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TestStoryboard.storyboard; sourceTree = "<group>"; };
 		3C0754B41DD0D5CA004DAB38 /* TestViewWithoutOwner.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TestViewWithoutOwner.xib; sourceTree = "<group>"; };
-		3C48A8231DB8CD060014CBE9 /* UIImage+ColorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+ColorTest.swift"; sourceTree = "<group>"; };
-		3C5C99571DB8E8EC00083A4E /* TimeInterval+ConverterTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ConverterTest.swift"; sourceTree = "<group>"; };
-		3C5C99591DB8EDE700083A4E /* UIView+XibTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+XibTest.swift"; sourceTree = "<group>"; };
+		3C48A8231DB8CD060014CBE9 /* UIImageColorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageColorTest.swift; sourceTree = "<group>"; };
+		3C5C99571DB8E8EC00083A4E /* TimeIntervalConverterTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeIntervalConverterTest.swift; sourceTree = "<group>"; };
+		3C5C99591DB8EDE700083A4E /* UIViewXibTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewXibTest.swift; sourceTree = "<group>"; };
 		3C5C995D1DB8F7D300083A4E /* TestViewWithOwner.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TestViewWithOwner.xib; sourceTree = "<group>"; };
 		3C5C99691DB8F9BE00083A4E /* NibViewTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibViewTest.swift; sourceTree = "<group>"; };
 		718A84852073739A0050CE40 /* .swift-version */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".swift-version"; sourceTree = "<group>"; };
@@ -217,10 +217,10 @@
 		740682731D36969D00FEA974 /* Dictionary+MapValuesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Dictionary+MapValuesTests.swift"; path = "Tests/ViaSwiftUtilsTests/Dictionary+MapValuesTests.swift"; sourceTree = SOURCE_ROOT; };
 		740682761D3696A500FEA974 /* Date_ComponentAccessorsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Date_ComponentAccessorsTest.swift; path = Tests/ViaSwiftUtilsTests/Date_ComponentAccessorsTest.swift; sourceTree = SOURCE_ROOT; };
 		740682781D3696AA00FEA974 /* Date_ComparableTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Date_ComparableTest.swift; path = Tests/ViaSwiftUtilsTests/Date_ComparableTest.swift; sourceTree = SOURCE_ROOT; };
-		7406827A1D3696B100FEA974 /* UIButton+StateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIButton+StateTests.swift"; path = "iOSTests/UIButton+StateTests.swift"; sourceTree = SOURCE_ROOT; };
-		7406827C1D3696B700FEA974 /* UIImageView_RotationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIImageView_RotationTests.swift; path = iOSTests/UIImageView_RotationTests.swift; sourceTree = SOURCE_ROOT; };
-		740CDBD41F2613270071BF63 /* Locale+Swizzling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Locale+Swizzling.swift"; sourceTree = "<group>"; };
-		740CDBD61F2614FF0071BF63 /* TimeInterval+ConverterTestsArabic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ConverterTestsArabic.swift"; sourceTree = "<group>"; };
+		7406827A1D3696B100FEA974 /* UIButtonStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIButtonStateTests.swift; path = iOSTests/UIButtonStateTests.swift; sourceTree = SOURCE_ROOT; };
+		7406827C1D3696B700FEA974 /* UIImageViewRotationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIImageViewRotationTests.swift; path = iOSTests/UIImageViewRotationTests.swift; sourceTree = SOURCE_ROOT; };
+		740CDBD41F2613270071BF63 /* NSLocale+Swizzling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLocale+Swizzling.swift"; sourceTree = "<group>"; };
+		740CDBD61F2614FF0071BF63 /* TimeIntervalConverterArabicTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeIntervalConverterArabicTest.swift; sourceTree = "<group>"; };
 		742194951D785C5F00A73CF0 /* Date_TimesBetween.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Date_TimesBetween.swift; path = Tests/ViaSwiftUtilsTests/Date_TimesBetween.swift; sourceTree = SOURCE_ROOT; };
 		742C87711F2748F500DC39AE /* CountableRange+Random.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CountableRange+Random.swift"; sourceTree = "<group>"; };
 		742C87721F2748F500DC39AE /* Date+ComponentAccessors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+ComponentAccessors.swift"; sourceTree = "<group>"; };
@@ -231,7 +231,7 @@
 		742C87771F2748F500DC39AE /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		742C87781F2748F500DC39AE /* ObserverType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObserverType.swift; sourceTree = "<group>"; };
 		742C87791F2748F500DC39AE /* RandomAccessCollection+SafeAccess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RandomAccessCollection+SafeAccess.swift"; sourceTree = "<group>"; };
-		742C877A1F2748F500DC39AE /* SequenceType+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SequenceType+Helpers.swift"; sourceTree = "<group>"; };
+		742C877A1F2748F500DC39AE /* Sequence+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sequence+Helpers.swift"; sourceTree = "<group>"; };
 		742C877B1F2748F500DC39AE /* SignedInteger+Random.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SignedInteger+Random.swift"; sourceTree = "<group>"; };
 		742C877D1F2748F500DC39AE /* String+Words.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Words.swift"; sourceTree = "<group>"; };
 		742C877E1F2748F500DC39AE /* TimeInterval+Converter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Converter.swift"; sourceTree = "<group>"; };
@@ -239,7 +239,7 @@
 		742C87811F2748F500DC39AE /* Bundle+ApplicationInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+ApplicationInfo.swift"; sourceTree = "<group>"; };
 		742C87821F2748F500DC39AE /* NibView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibView.swift; sourceTree = "<group>"; };
 		742C87831F2748F500DC39AE /* UIButton+States.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+States.swift"; sourceTree = "<group>"; };
-		742C87841F2748F500DC39AE /* UIControlState+States.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControlState+States.swift"; sourceTree = "<group>"; };
+		742C87841F2748F500DC39AE /* UIControl+States.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+States.swift"; sourceTree = "<group>"; };
 		742C87851F2748F500DC39AE /* UIImage+Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Color.swift"; sourceTree = "<group>"; };
 		742C87861F2748F500DC39AE /* UIImage+Rounding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Rounding.swift"; sourceTree = "<group>"; };
 		742C87871F2748F500DC39AE /* UIImageView+Rotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImageView+Rotation.swift"; sourceTree = "<group>"; };
@@ -291,8 +291,8 @@
 		74E063F71D1D7F4700C0B56B /* ViaSwiftUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ViaSwiftUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74E064041D1D7F7D00C0B56B /* ViaSwiftUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ViaSwiftUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE18E17B1D912A82003C8267 /* CGPoint+OperatorsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGPoint+OperatorsTest.swift"; sourceTree = "<group>"; };
-		CE2433261D913EB0001D6CC1 /* CGVector+OperatorsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGVector+OperatorsTest.swift"; sourceTree = "<group>"; };
-		CE65B3611D8AAD9700AA9B2B /* String+WordsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+WordsTest.swift"; sourceTree = "<group>"; };
+		CE2433261D913EB0001D6CC1 /* CGVectorOperatorsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGVectorOperatorsTest.swift; sourceTree = "<group>"; };
+		CE65B3611D8AAD9700AA9B2B /* StringWordsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringWordsTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -365,7 +365,7 @@
 				742C87771F2748F500DC39AE /* Observable.swift */,
 				742C87781F2748F500DC39AE /* ObserverType.swift */,
 				742C87791F2748F500DC39AE /* RandomAccessCollection+SafeAccess.swift */,
-				742C877A1F2748F500DC39AE /* SequenceType+Helpers.swift */,
+				742C877A1F2748F500DC39AE /* Sequence+Helpers.swift */,
 				742C877B1F2748F500DC39AE /* SignedInteger+Random.swift */,
 				742C877E1F2748F500DC39AE /* TimeInterval+Converter.swift */,
 				742C877F1F2748F500DC39AE /* TimeInterval+Intervals.swift */,
@@ -383,7 +383,7 @@
 				742C87821F2748F500DC39AE /* NibView.swift */,
 				745D357A1F3070FE0039BC14 /* String+Localized.swift */,
 				742C87831F2748F500DC39AE /* UIButton+States.swift */,
-				742C87841F2748F500DC39AE /* UIControlState+States.swift */,
+				742C87841F2748F500DC39AE /* UIControl+States.swift */,
 				742C87851F2748F500DC39AE /* UIImage+Color.swift */,
 				742C87861F2748F500DC39AE /* UIImage+Rounding.swift */,
 				742C87871F2748F500DC39AE /* UIImageView+Rotation.swift */,
@@ -444,16 +444,16 @@
 		74DC1C621D1D8CF5007F1853 /* iOSTests */ = {
 			isa = PBXGroup;
 			children = (
-				3C5C99571DB8E8EC00083A4E /* TimeInterval+ConverterTest.swift */,
-				740CDBD61F2614FF0071BF63 /* TimeInterval+ConverterTestsArabic.swift */,
-				CE2433261D913EB0001D6CC1 /* CGVector+OperatorsTest.swift */,
-				7406827A1D3696B100FEA974 /* UIButton+StateTests.swift */,
-				7406827C1D3696B700FEA974 /* UIImageView_RotationTests.swift */,
-				3C48A8231DB8CD060014CBE9 /* UIImage+ColorTest.swift */,
-				3C5C99591DB8EDE700083A4E /* UIView+XibTest.swift */,
+				3C5C99571DB8E8EC00083A4E /* TimeIntervalConverterTest.swift */,
+				740CDBD61F2614FF0071BF63 /* TimeIntervalConverterArabicTest.swift */,
+				CE2433261D913EB0001D6CC1 /* CGVectorOperatorsTest.swift */,
+				7406827A1D3696B100FEA974 /* UIButtonStateTests.swift */,
+				7406827C1D3696B700FEA974 /* UIImageViewRotationTests.swift */,
+				3C48A8231DB8CD060014CBE9 /* UIImageColorTest.swift */,
+				3C5C99591DB8EDE700083A4E /* UIViewXibTest.swift */,
 				3C5C99691DB8F9BE00083A4E /* NibViewTest.swift */,
-				740CDBD41F2613270071BF63 /* Locale+Swizzling.swift */,
-				CE65B3611D8AAD9700AA9B2B /* String+WordsTest.swift */,
+				740CDBD41F2613270071BF63 /* NSLocale+Swizzling.swift */,
+				CE65B3611D8AAD9700AA9B2B /* StringWordsTest.swift */,
 				3C0754AF1DD0C15C004DAB38 /* TestStoryboard.storyboard */,
 				3C5C995D1DB8F7D300083A4E /* TestViewWithOwner.xib */,
 				3C0754B41DD0D5CA004DAB38 /* TestViewWithoutOwner.xib */,
@@ -676,7 +676,7 @@
 				74E063D71D1D7E8000C0B56B /* Frameworks */,
 				74E063D81D1D7E8000C0B56B /* Headers */,
 				74E063D91D1D7E8000C0B56B /* Resources */,
-				74EEA8051D3CE5A700B9905A /* ShellScript */,
+				74EEA8051D3CE5A700B9905A /* Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -868,18 +868,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		74EEA8051D3CE5A700B9905A /* ShellScript */ = {
+		74EEA8051D3CE5A700B9905A /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = Swiftlint;
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -889,25 +890,25 @@
 			buildActionMask = 2147483647;
 			files = (
 				3C5C996A1DB8F9BE00083A4E /* NibViewTest.swift in Sources */,
-				740CDBD51F2613270071BF63 /* Locale+Swizzling.swift in Sources */,
-				7406827E1D36976200FEA974 /* UIImageView_RotationTests.swift in Sources */,
+				740CDBD51F2613270071BF63 /* NSLocale+Swizzling.swift in Sources */,
+				7406827E1D36976200FEA974 /* UIImageViewRotationTests.swift in Sources */,
 				740682751D36969D00FEA974 /* Dictionary+MapValuesTests.swift in Sources */,
-				3C48A8241DB8CD060014CBE9 /* UIImage+ColorTest.swift in Sources */,
-				CE65B3621D8AAD9700AA9B2B /* String+WordsTest.swift in Sources */,
+				3C48A8241DB8CD060014CBE9 /* UIImageColorTest.swift in Sources */,
+				CE65B3621D8AAD9700AA9B2B /* StringWordsTest.swift in Sources */,
 				740682771D3696A500FEA974 /* Date_ComponentAccessorsTest.swift in Sources */,
 				740682741D36969D00FEA974 /* SequenceTypeHelperTests.swift in Sources */,
 				74DC1CD01D212967007F1853 /* CGRectTests.swift in Sources */,
-				CE2433281D913EB4001D6CC1 /* CGVector+OperatorsTest.swift in Sources */,
-				740CDBD71F2614FF0071BF63 /* TimeInterval+ConverterTestsArabic.swift in Sources */,
+				CE2433281D913EB4001D6CC1 /* CGVectorOperatorsTest.swift in Sources */,
+				740CDBD71F2614FF0071BF63 /* TimeIntervalConverterArabicTest.swift in Sources */,
 				CE18E17D1D912A87003C8267 /* CGPoint+OperatorsTest.swift in Sources */,
-				7406827B1D3696B100FEA974 /* UIButton+StateTests.swift in Sources */,
+				7406827B1D3696B100FEA974 /* UIButtonStateTests.swift in Sources */,
 				33AED1841ECE0814002B70CD /* RandomAccessCollection+SafeAccessTests.swift in Sources */,
 				7453400B1DDCC061008029C1 /* BetterForceUnwrappingTests.swift in Sources */,
 				740682791D3696AA00FEA974 /* Date_ComparableTest.swift in Sources */,
 				742194991D785F1000A73CF0 /* Date_TimesBetween.swift in Sources */,
-				3C5C99581DB8E8EC00083A4E /* TimeInterval+ConverterTest.swift in Sources */,
+				3C5C99581DB8E8EC00083A4E /* TimeIntervalConverterTest.swift in Sources */,
 				740682711D3630AA00FEA974 /* CollectionShuffledTest.swift in Sources */,
-				3C5C995A1DB8EDE700083A4E /* UIView+XibTest.swift in Sources */,
+				3C5C995A1DB8EDE700083A4E /* UIViewXibTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -948,7 +949,7 @@
 				742C87BC1F2748F500DC39AE /* TimeInterval+Intervals.swift in Sources */,
 				742C87C51F2748F500DC39AE /* UIButton+States.swift in Sources */,
 				745D357B1F3070FE0039BC14 /* String+Localized.swift in Sources */,
-				742C87AD1F2748F500DC39AE /* SequenceType+Helpers.swift in Sources */,
+				742C87AD1F2748F500DC39AE /* Sequence+Helpers.swift in Sources */,
 				742C87C21F2748F500DC39AE /* NibView.swift in Sources */,
 				745D35821F3071E00039BC14 /* CGRect+AspectRatio.swift in Sources */,
 				742C87921F2748F500DC39AE /* CountableRange+Random.swift in Sources */,
@@ -957,7 +958,7 @@
 				742C87CB1F2748F500DC39AE /* UIImage+Color.swift in Sources */,
 				742C87CE1F2748F500DC39AE /* UIImage+Rounding.swift in Sources */,
 				742C87BF1F2748F500DC39AE /* Bundle+ApplicationInfo.swift in Sources */,
-				742C87C81F2748F500DC39AE /* UIControlState+States.swift in Sources */,
+				742C87C81F2748F500DC39AE /* UIControl+States.swift in Sources */,
 				742C87D11F2748F500DC39AE /* UIImageView+Rotation.swift in Sources */,
 				742C87A71F2748F500DC39AE /* ObserverType.swift in Sources */,
 				745D35801F3071E00039BC14 /* CGPoint+Operators.swift in Sources */,
@@ -979,7 +980,7 @@
 				742C87A21F2748F500DC39AE /* MutableCollection+Shuffle.swift in Sources */,
 				742C87AB1F2748F500DC39AE /* RandomAccessCollection+SafeAccess.swift in Sources */,
 				742C87BD1F2748F500DC39AE /* TimeInterval+Intervals.swift in Sources */,
-				742C87AE1F2748F500DC39AE /* SequenceType+Helpers.swift in Sources */,
+				742C87AE1F2748F500DC39AE /* Sequence+Helpers.swift in Sources */,
 				742C87931F2748F500DC39AE /* CountableRange+Random.swift in Sources */,
 				742C879F1F2748F500DC39AE /* ForceUnwrappingOperators.swift in Sources */,
 				742C87A81F2748F500DC39AE /* ObserverType.swift in Sources */,
@@ -1002,7 +1003,7 @@
 				742C87BE1F2748F500DC39AE /* TimeInterval+Intervals.swift in Sources */,
 				742C87C71F2748F500DC39AE /* UIButton+States.swift in Sources */,
 				745D357C1F3070FE0039BC14 /* String+Localized.swift in Sources */,
-				742C87AF1F2748F500DC39AE /* SequenceType+Helpers.swift in Sources */,
+				742C87AF1F2748F500DC39AE /* Sequence+Helpers.swift in Sources */,
 				742C87C41F2748F500DC39AE /* NibView.swift in Sources */,
 				745D35831F3071E00039BC14 /* CGRect+AspectRatio.swift in Sources */,
 				742C87941F2748F500DC39AE /* CountableRange+Random.swift in Sources */,
@@ -1011,7 +1012,7 @@
 				742C87CD1F2748F500DC39AE /* UIImage+Color.swift in Sources */,
 				742C87D01F2748F500DC39AE /* UIImage+Rounding.swift in Sources */,
 				742C87C11F2748F500DC39AE /* Bundle+ApplicationInfo.swift in Sources */,
-				742C87CA1F2748F500DC39AE /* UIControlState+States.swift in Sources */,
+				742C87CA1F2748F500DC39AE /* UIControl+States.swift in Sources */,
 				742C87D31F2748F500DC39AE /* UIImageView+Rotation.swift in Sources */,
 				742C87A91F2748F500DC39AE /* ObserverType.swift in Sources */,
 				745D35811F3071E00039BC14 /* CGPoint+Operators.swift in Sources */,

--- a/iOSTests/CGVectorOperatorsTest.swift
+++ b/iOSTests/CGVectorOperatorsTest.swift
@@ -1,5 +1,5 @@
 //
-//  CGVector+OperatorsTest.swift
+//  CGVectorOperatorsTest.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.

--- a/iOSTests/NSLocale+Swizzling.swift
+++ b/iOSTests/NSLocale+Swizzling.swift
@@ -1,5 +1,5 @@
 //
-//  Locale+Swizzling.swift
+//  NSLocale+Swizzling.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.

--- a/iOSTests/NibViewTest.swift
+++ b/iOSTests/NibViewTest.swift
@@ -20,11 +20,12 @@ import Foundation
 @testable import ViaSwiftUtils
 import XCTest
 
+//swiftlint:disable strict_fileprivate
 class TestViewController: UIViewController {
 
     @IBOutlet fileprivate var horizontalTestViewConstraint: NSLayoutConstraint?
     @IBOutlet fileprivate var testView: TestViewWithOwner?
-    
+
 }
 
 class TestViewWithOwner: NibView {
@@ -33,6 +34,7 @@ class TestViewWithOwner: NibView {
     @IBOutlet fileprivate var testLabel: UILabel?
 
 }
+//swiftlint:enable strict_fileprivate
 
 class NibViewTest: XCTestCase {
 
@@ -64,12 +66,10 @@ class NibViewTest: XCTestCase {
         let testView = TestViewWithOwner(frame: frame)
 
         // Then
-        XCTAssertEqual(testView.subviews.count, expectedNumberOfSubviews,
-                       "Expected number of subviews to be \(expectedNumberOfSubviews)")
+        XCTAssertEqual(testView.subviews.count, expectedNumberOfSubviews, "Expected number of subviews to be \(expectedNumberOfSubviews)")
 
         let subviewType = String(describing: type(of: testView.subviews[0]))
-        XCTAssertEqual(subviewType, expectedSubviewType,
-                       "Expected subview type to be \(expectedSubviewType)")
+        XCTAssertEqual(subviewType, expectedSubviewType, "Expected subview type to be \(expectedSubviewType)")
     }
 
     func testInitializationWithCoder() {
@@ -87,12 +87,10 @@ class NibViewTest: XCTestCase {
         // Then
         XCTAssertNotNil(unarchivedTestView, "Expected unarchived view not to be nil")
         unarchivedTestView.map {
-            XCTAssertEqual($0.subviews.count, expectedNumberOfSubviews,
-                           "Expected number of subviews to be \(expectedNumberOfSubviews)")
+            XCTAssertEqual($0.subviews.count, expectedNumberOfSubviews, "Expected number of subviews to be \(expectedNumberOfSubviews)")
 
             let subviewType = String(describing: type(of: $0.subviews[0]))
-            XCTAssertEqual(subviewType, expectedSubviewType,
-                           "Expected subview type to be \(expectedSubviewType)")
+            XCTAssertEqual(subviewType, expectedSubviewType, "Expected subview type to be \(expectedSubviewType)")
         }
     }
 

--- a/iOSTests/StringWordsTest.swift
+++ b/iOSTests/StringWordsTest.swift
@@ -1,5 +1,5 @@
 //
-//  String+WordsTest.swift
+//  StringWordsTest.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.

--- a/iOSTests/TimeIntervalConverterArabicTest.swift
+++ b/iOSTests/TimeIntervalConverterArabicTest.swift
@@ -1,5 +1,5 @@
 //
-//  TimeInterval+ConverterTest.swift
+//  TimeIntervalConverterArabicTest.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.
@@ -20,12 +20,12 @@ import Foundation
 @testable import ViaSwiftUtils
 import XCTest
 
-class TimeIntervalConverterTest: XCTestCase {
+class TimeIntervalConverterArabicTest: XCTestCase {
     
     override func setUp() {
         super.setUp()
         
-        NSLocale.forceLocale(identifier: "en_US")
+        NSLocale.forceLocale(identifier: "ar_SA")
     }
     
     override func tearDown() {
@@ -42,54 +42,50 @@ class TimeIntervalConverterTest: XCTestCase {
         let formattedString = interval.asMediaDuration
         
         // Then
-        let expected = "18:37"
-        XCTAssertEqual(formattedString, expected,
-                       "Expected string \(expected)")
+        let expected = "١٨:٣٧"
+        XCTAssertEqual(formattedString, expected, "Expected string \(expected)")
     }
-
+    
     func testToStringMinutes() {
         // Given
         let format = "mm:ss"
         let interval = 600
         let expected = "10:00"
         let timeInterval = TimeInterval(interval)
-
+        
         // When
         let formattedString = timeInterval.string(withFormat: format)
-
+        
         // Then
-        XCTAssertEqual(formattedString, expected,
-                       "Expected string \(expected)")
+        XCTAssertEqual(formattedString, expected, "Expected string \(expected) even when locale is \(Locale.current)")
     }
-
+    
     func testSecondsToStringHours() {
         // Given
         let format = "mm:ss"
         let interval = 3603
         let expected = "00:03"
         let timeInterval = TimeInterval(interval)
-
+        
         // When
         let formattedString = timeInterval.string(withFormat: format)
-
+        
         // Then
-        XCTAssertEqual(formattedString, expected,
-                       "Expected string \(expected)")
+        XCTAssertEqual(formattedString, expected, "Expected string \(expected) even when locale is \(Locale.current)")
     }
-
+    
     func testSecondsToStringYears() {
         // Given
         let format = "yyyy, mm:ss"
         let interval = 360_045_003
         let expected = "1981, 30:03"
         let timeInterval = TimeInterval(interval)
-
+        
         // When
         let formattedString = timeInterval.string(withFormat: format)
-
+        
         // Then
-        XCTAssertEqual(formattedString, expected,
-                       "Expected string \(expected)")
+        XCTAssertEqual(formattedString, expected, "Expected string \(expected) even when locale is \(Locale.current)")
     }
     
 }

--- a/iOSTests/TimeIntervalConverterTest.swift
+++ b/iOSTests/TimeIntervalConverterTest.swift
@@ -1,5 +1,5 @@
 //
-//  TimeInterval+ConverterTestsArabic.swift
+//  TimeIntervalConverterTest.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.
@@ -20,12 +20,12 @@ import Foundation
 @testable import ViaSwiftUtils
 import XCTest
 
-class TimeIntervalConverterArabicTest: XCTestCase {
+class TimeIntervalConverterTest: XCTestCase {
     
     override func setUp() {
         super.setUp()
         
-        NSLocale.forceLocale(identifier: "ar_SA")
+        NSLocale.forceLocale(identifier: "en_US")
     }
     
     override func tearDown() {
@@ -42,54 +42,50 @@ class TimeIntervalConverterArabicTest: XCTestCase {
         let formattedString = interval.asMediaDuration
         
         // Then
-        let expected = "١٨:٣٧"
-        XCTAssertEqual(formattedString, expected,
-                       "Expected string \(expected)")
+        let expected = "18:37"
+        XCTAssertEqual(formattedString, expected, "Expected string \(expected)")
     }
-    
+
     func testToStringMinutes() {
         // Given
         let format = "mm:ss"
         let interval = 600
         let expected = "10:00"
         let timeInterval = TimeInterval(interval)
-        
+
         // When
         let formattedString = timeInterval.string(withFormat: format)
-        
+
         // Then
-        XCTAssertEqual(formattedString, expected,
-                       "Expected string \(expected) even when locale is \(Locale.current)")
+        XCTAssertEqual(formattedString, expected, "Expected string \(expected)")
     }
-    
+
     func testSecondsToStringHours() {
         // Given
         let format = "mm:ss"
         let interval = 3603
         let expected = "00:03"
         let timeInterval = TimeInterval(interval)
-        
+
         // When
         let formattedString = timeInterval.string(withFormat: format)
-        
+
         // Then
-        XCTAssertEqual(formattedString, expected,
-                       "Expected string \(expected) even when locale is \(Locale.current)")
+        XCTAssertEqual(formattedString, expected, "Expected string \(expected)")
     }
-    
+
     func testSecondsToStringYears() {
         // Given
         let format = "yyyy, mm:ss"
         let interval = 360_045_003
         let expected = "1981, 30:03"
         let timeInterval = TimeInterval(interval)
-        
+
         // When
         let formattedString = timeInterval.string(withFormat: format)
-        
+
         // Then
-        XCTAssertEqual(formattedString, expected,
-                       "Expected string \(expected) even when locale is \(Locale.current)")
+        XCTAssertEqual(formattedString, expected, "Expected string \(expected)")
     }
     
 }

--- a/iOSTests/UIButtonStateTests.swift
+++ b/iOSTests/UIButtonStateTests.swift
@@ -1,5 +1,5 @@
 //
-//  UIButton+StateTests.swift
+//  UIButtonStateTests.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.
@@ -67,13 +67,17 @@ class UIButtonStateTests: XCTestCase {
         button.setImagesForStates(normal: frontImageNormal, highlighted: frontImageHighlighted, selected: frontImageSelected, climax: frontImageClimax )
 
         // Then
-        XCTAssertEqual(button.image(for: .normal), frontImageNormal,
+        XCTAssertEqual(button.image(for: .normal),
+                       frontImageNormal,
                        "Expected image for state \(UIControl.State.normal) to be frontImageNormal")
-        XCTAssertEqual(button.image(for: .highlighted), frontImageHighlighted,
+        XCTAssertEqual(button.image(for: .highlighted),
+                       frontImageHighlighted,
                        "Expected image for state \(UIControl.State.highlighted) to be frontImageHighlighted")
-        XCTAssertEqual(button.image(for: .selected), frontImageSelected,
+        XCTAssertEqual(button.image(for: .selected),
+                       frontImageSelected,
                        "Expected image for state \(UIControl.State.selected) to be frontImageSelected")
-        XCTAssertEqual(button.image(for: [.selected, .highlighted]), frontImageClimax,
+        XCTAssertEqual(button.image(for: [.selected, .highlighted]),
+                       frontImageClimax,
                        "Expected image for state \([UIControl.State.selected, UIControl.State.highlighted]) to be frontImageClimax")
     }
 

--- a/iOSTests/UIImageColorTest.swift
+++ b/iOSTests/UIImageColorTest.swift
@@ -1,5 +1,5 @@
 //
-//  UIImage+ColorTest.swift
+//  UIImageColorTest.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.
@@ -19,7 +19,7 @@
 @testable import ViaSwiftUtils
 import XCTest
 
-class UIButtonColorTest: XCTestCase {
+class UIImageColorTest: XCTestCase {
 
     func testConvenienceFailableInitializer() {
         // Given

--- a/iOSTests/UIImageViewRotationTests.swift
+++ b/iOSTests/UIImageViewRotationTests.swift
@@ -1,5 +1,5 @@
 //
-//  UIImageView_RotationTests.swift
+//  UIImageViewRotationTests.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.
@@ -86,10 +86,10 @@ class UIImageViewRotationTests: XCTestCase {
         imageView.startRotating(isRemovedOnCompletion: false)
         
         // Then
-        if let animation = imageView.layer.animation(forKey: viewRotationAnimationKey) {
+        if let animation = imageView.layer.animation(forKey: RotationAnimation.key) {
             XCTAssertFalse(animation.isRemovedOnCompletion)
         } else {
-            XCTFail("imageView is missing animation for \(viewRotationAnimationKey)")
+            XCTFail("imageView is missing animation for \(RotationAnimation.key)")
         }
     }
     

--- a/iOSTests/UIViewXibTest.swift
+++ b/iOSTests/UIViewXibTest.swift
@@ -1,5 +1,5 @@
 //
-//  UIView+XibTest.swift
+//  UIViewXibTest.swift
 //  ViaSwiftUtils
 //
 //  Copyright 2017 Viacom, Inc.
@@ -38,12 +38,10 @@ class UIViewXibTest: XCTestCase {
         testView.loadNibView(owner)
 
         // Then
-        XCTAssertEqual(testView.subviews.count, expectedNumberOfSubviews,
-                       "Expected number of subviews to be \(expectedNumberOfSubviews)")
+        XCTAssertEqual(testView.subviews.count, expectedNumberOfSubviews, "Expected number of subviews to be \(expectedNumberOfSubviews)")
         
         let subviewType = String(describing: type(of: testView.subviews[0]))
-        XCTAssertEqual(subviewType, expectedSubviewType,
-                       "Expected subview type to be \(expectedSubviewType)")
+        XCTAssertEqual(subviewType, expectedSubviewType, "Expected subview type to be \(expectedSubviewType)")
     }
 
     func testLoadFromNib() {
@@ -58,8 +56,7 @@ class UIViewXibTest: XCTestCase {
         XCTAssertNotNil(view, "Expected view not to be nil")
         view.map {
             let subviewType = String(describing: type(of: $0))
-            XCTAssertEqual(subviewType, expectedSubviewType,
-                           "Expected view type to be \(expectedSubviewType)")
+            XCTAssertEqual(subviewType, expectedSubviewType, "Expected view type to be \(expectedSubviewType)")
         }
     }
 

--- a/install_swiftlint.sh
+++ b/install_swiftlint.sh
@@ -7,7 +7,7 @@
 set -e
 
 SWIFTLINT_PKG_PATH="/tmp/SwiftLint.pkg"
-SWIFTLINT_PKG_URL="https://github.com/realm/SwiftLint/releases/download/0.31.0/SwiftLint.pkg"
+SWIFTLINT_PKG_URL="https://github.com/realm/SwiftLint/releases/download/0.38.0/SwiftLint.pkg"
 
 wget --output-document=$SWIFTLINT_PKG_PATH $SWIFTLINT_PKG_URL
 


### PR DESCRIPTION
This PR updates swiftlint to version 0.38.0. Project now opts-in to a great number of new rules. Finally, source code has been cleaned to follow new rules.